### PR TITLE
Skip css comments.

### DIFF
--- a/lib/cssToJss.js
+++ b/lib/cssToJss.js
@@ -29,6 +29,7 @@ function toJssRules(cssRules) {
     var jssRules = {}
 
     function addRule(rule, rules) {
+        if (rule.type == 'comment') { return }
         var key, style = {}
         key = rule.selectors.join(', ')
         rule.declarations.forEach(function (decl) {


### PR DESCRIPTION
Without this change the transform will fail with even the most basic CSS files that have comments.
