### PR TITLE
Ignore comments when adding rules

### DIFF
--- a/lib/cssToJss.js
+++ b/lib/cssToJss.js
@@ -29,6 +29,7 @@ function toJssRules(cssRules) {
   var jssRules = {}
 
   function addRule(rule, rules) {
+    if (rule.type === 'comment') return
     var key, style = {}
     key = rule.selectors.join(', ')
     rule.declarations.forEach(function (decl) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jss-cli",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A command line tool for JSS",
   "bin": {
     "jss": "bin/jss.js"


### PR DESCRIPTION
CSS comment rules don't have selectors or declarations properties therefore when processed inside the addRule function they will throw with an exception. This patch fixes this.
