### PR TITLE
Possible fix css package error

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "http://cssinjs.org",
   "dependencies": {
     "commander": "^2.8.1",
-    "css": "^2.2.0",
+    "css": "*",
     "jss": "^9.0.0",
     "jss-preset-default": "^4.0.1",
     "lodash": "^4.17.4",


### PR DESCRIPTION
Hi! Lib doen't work, look at error

```$ ../../node_modules/.bin/jss convert font-awesome.css -f js -e es6 > fontAwesome.style.js
/Users/work/www/rtd/node_modules/css/lib/parse/index.js:72
      throw err;
      ^

Error: undefined:1:17: missing '{'
    at error (/Users/work/www/rtd/node_modules/css/lib/parse/index.js:62:15)
    at declarations (/Users/work/www/rtd/node_modules/css/lib/parse/index.js:247:25)
    at rule (/Users/work/www/rtd/node_modules/css/lib/parse/index.js:560:21)
    at rules (/Users/work/www/rtd/node_modules/css/lib/parse/index.js:117:70)
    at stylesheet (/Users/work/www/rtd/node_modules/css/lib/parse/index.js:81:21)
    at Object.module.exports [as parse] (/Users/work/www/rtd/node_modules/css/lib/parse/index.js:564:20)
    at module.exports (/Users/work/www/rtd/node_modules/jss-cli/lib/cssToJss.js:12:19)
    at convert (/Users/work/www/rtd/node_modules/jss-cli/bin/jss.js:40:19)
    at Command.onConvert (/Users/work/www/rtd/node_modules/jss-cli/bin/jss.js:82:26)
    at Command.listener (/Users/work/www/rtd/node_modules/commander/index.js:315:8)```