### PR TITLE
Support for vendor prefixes

### DIFF
--- a/lib/cssToJss.js
+++ b/lib/cssToJss.js
@@ -58,12 +58,9 @@ function toJssRules(cssRules, options) {
   }
 
   function formatProp(prop) {
-    if (options.dashes) {
-      // Capitalize the first character
-      return (typeof prop === 'string' && prop.substring(0, 1) === '-') ?
-        camelCase(prop).charAt(0).toUpperCase() : camelCase(prop)
-    }
-    return prop
+    // Capitalize the first character
+    return options.dashes ? prop : (typeof prop === 'string' && prop.substring(0, 1) === '-') ?
+      camelCase(prop).charAt(0).toUpperCase() : camelCase(prop)
   }
 
   cssRules.forEach(function (rule) {

--- a/lib/cssToJss.js
+++ b/lib/cssToJss.js
@@ -58,7 +58,12 @@ function toJssRules(cssRules, options) {
   }
 
   function formatProp(prop) {
-    return options.dashes ? prop : camelCase(prop)
+    if (options.dashes) {
+      // Capitalize the first character
+      return (typeof prop === 'string' && prop.substring(0, 1) === '-') ?
+        camelCase(prop).charAt(0).toUpperCase() : camelCase(prop)
+    }
+    return prop
   }
 
   cssRules.forEach(function (rule) {


### PR DESCRIPTION
This fixes css attributes beginning with `-` from outputting incorrectly

```css
div {
  -webkit-transition: all 1s ease
}
```

### New output
```js
'div': {
   WebkitTransition: 'all 1s ease',
}
```

### Previous output
```js
'div': {
   webkitTransition: 'all 1s ease',
}
```