### PR TITLE
added support for @ page rule

### DIFF
--- a/lib/cssToJss.js
+++ b/lib/cssToJss.js
@@ -44,7 +44,7 @@ function toJssRules(cssRules, options) {
 
   function addRule(rule, rules) {
     if (rule.type === 'comment') return
-    const key = rule.selectors.join(', ')
+    const key = rule.type === 'page' ? '@page ' + rule.selectors.join(', ') : rule.selectors.join(', ')
     const style = rules[key] || (rules[key] = {})
     rule.declarations.forEach(function (decl) {
       if (decl.type === 'comment') return
@@ -67,6 +67,9 @@ function toJssRules(cssRules, options) {
     if (rule.type === 'comment') return
     switch (rule.type) {
       case 'rule':
+        addRule(rule, jssRules)
+        break
+      case 'page':
         addRule(rule, jssRules)
         break
       case 'media': {


### PR DESCRIPTION
Added support for @ page rule

if rule.type === 'page' then i added the @ page rule + the selectors.

i also added a case for type 'page'.

Results:
```
"@page": {
        "margin": "2cm",
},
"@page :left": {
        "margin-left": "4cm",
        "margin-right": "3cm"
},
 "@page :right": {
        "margin-left": "4cm",
        "margin-right": "3cm"
}
```
