### PR TITLE
#573 [cli] Parse error when using filename as a path

### DIFF
--- a/bin/jss.js
+++ b/bin/jss.js
@@ -24,7 +24,7 @@ function convert(src) {
   var converter = formatConverterMap[program.format]
 
   // We assume its a path.
-  if (src.split('\n')[0].indexOf(path.sep) !== -1) {
+  if (src.split('\n')[0].indexOf(path.sep) !== -1 || path.extname(src) === '.css') {
     if (!path.isAbsolute(src)) src = path.resolve(process.cwd(), src)
     src = fs.readFileSync(src, 'utf-8')
   }


### PR DESCRIPTION
This PR attempts to resolve https://github.com/cssinjs/jss/issues/573, by resolving paths when a filename has `.css` extension.