### PR TITLE
fix output escaping

### DIFF
--- a/example/style.css
+++ b/example/style.css
@@ -29,7 +29,7 @@ body {
 }
 
 #big-bang::before {
-  content: "";
+  content: "\ffff";
 }
 
 #titanic {

--- a/lib/cssToJss.js
+++ b/lib/cssToJss.js
@@ -53,7 +53,7 @@ function toJssRules(cssRules, options) {
         const fallbacks = style.fallbacks || (style.fallbacks = [])
         fallbacks.splice(0, 0, { [property]: style[property] })
       }
-      style[property] = stripUnit(decl.value)
+      style[property] = stripUnit(decl.value).replace(/\\/g, '\\\\')
     })
   }
 


### PR DESCRIPTION
During a conversion process via command
```
jss convert style.css -f js -e cjs > style.js
```
escaping characters should be escaped:
```css
#big-bang::before {
  content: "\ffff";
}
```
should became
```css
#big-bang::before {
  content: "\\ffff";
}
```
