### PR TITLE
fix escaping non-string values

### DIFF
--- a/example/style.css
+++ b/example/style.css
@@ -13,6 +13,7 @@ body {
 
 .delorean {
   z-index: -1955;
+  width: 5px;
 }
 
 #chucknorris {

--- a/lib/cssToJss.js
+++ b/lib/cssToJss.js
@@ -53,7 +53,10 @@ function toJssRules(cssRules, options) {
         const fallbacks = style.fallbacks || (style.fallbacks = [])
         fallbacks.splice(0, 0, { [property]: style[property] })
       }
-      style[property] = stripUnit(decl.value).replace(/\\/g, '\\\\')
+      style[property] = stripUnit(decl.value)
+      if (typeof style[property] === 'string') {
+        style[property] = style[property].replace(/\\/g, '\\\\')
+      }
     })
   }
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "jss": "bin/jss.js"
   },
   "scripts": {
-    "cssToJss": "node bin/cli example/style.css",
+    "cssToJss": "node bin/jss convert example/style.css -f js -e cjs",
     "example": "babel-node example/test.js"
   },
   "repository": {


### PR DESCRIPTION
Fixing the issue when `stripUnit` function returns a non-string value